### PR TITLE
Added Possibility to Use a Group of Rollershutters

### DIFF
--- a/src/ui/openhab/widgets/selection-control.vue
+++ b/src/ui/openhab/widgets/selection-control.vue
@@ -15,7 +15,11 @@
     export default class SelectionControl extends WidgetControl {
 
         get component(): new (...args: any[]) => WidgetControl {
-            switch (this.item && this.item.type) {
+            let itemType = this.item && this.item.type;
+            if (itemType === "Group" && this.item.groupType) {
+                itemType = this.item.groupType;
+            }
+            switch (itemType) {
                 case "Rollershutter":
                     return RollerShutter;
                 case "Player":

--- a/src/ui/openhab/widgets/switch-control.vue
+++ b/src/ui/openhab/widgets/switch-control.vue
@@ -16,7 +16,13 @@
             if (mappings && mappings.length) {
                 return false;
             }
-            return !equalsIgnoreCase("rollershutter", this.item.type);
+            if (equalsIgnoreCase("rollershutter", this.item.type)) {
+                return false;
+            }
+            if (equalsIgnoreCase("group", this.item.type) && equalsIgnoreCase("rollershutter", this.item.groupType)) {
+                return false;
+            }
+            return true;
         }
 
         get link(): Location {


### PR DESCRIPTION
Many thanks for this cool app.

These changes add support to use a rollershutter group

item
`Group:Rollershutter:AVG gRollershutters "Alle Rollershutters [%d %%]" `

sitemap
`Switch item=gRollershutters label="Alle Rollos" icon="rollershutter"`

Would be nice to have this added.
